### PR TITLE
remove modal backdrop.

### DIFF
--- a/dist/production.js
+++ b/dist/production.js
@@ -154,7 +154,7 @@ openHealthDataAppControllers.controller('mapCtrl', ['$scope', '$rootScope', '$ht
         controller: ModalInstanceCtrl,
         size: size,
         windowClass: 'modalContainer',
-        backdrop: true,
+        backdrop: false,
         resolve: {
           items: function () {
             return $scope.items;

--- a/js/controllers.js
+++ b/js/controllers.js
@@ -135,7 +135,7 @@ openHealthDataAppControllers.controller('mapCtrl', ['$scope', '$rootScope', '$ht
         controller: ModalInstanceCtrl,
         size: size,
         windowClass: 'modalContainer',
-        backdrop: true,
+        backdrop: false,
         resolve: {
           items: function () {
             return $scope.items;


### PR DESCRIPTION
modal backdrop is slow to dismiss on mobile, so removing it while we look for a better solution.
